### PR TITLE
coordinator api method for listing missing intervals

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,6 +26,7 @@ steps:
     GOOGLE_APPLICATION_CREDENTIALS: /tmp/key.json
     BROKER_HOST: "druid-broker-staging.in.globalwebindex.com"
     OVERLORD_HOST: "druid-overlord-staging.in.globalwebindex.com"
+    COORDINATOR_HOST: "druid-coordinator-staging.in.globalwebindex.com"
     TEST_CREDENTIALS:
       from_secret: sa_qpipeline_s
   volumes:

--- a/client/src/main/scala/gwi/druid/client/DruidClient.scala
+++ b/client/src/main/scala/gwi/druid/client/DruidClient.scala
@@ -350,7 +350,7 @@ object DruidClient extends DruidClient {
         }
 
     /**
-      * @return a set of segment intervals
+      * @return a set of missing intervals of given granularity within given range and datasource
       * @note that result is optional in case data-source is missing
       */
     def listMissingIntervals(range: Interval, granularity: Granularity, datasource: String): Try[Option[Vector[String]]] =

--- a/client/src/test/scala/gwi/druid/client/DruidIntegrationTestSuite.scala
+++ b/client/src/test/scala/gwi/druid/client/DruidIntegrationTestSuite.scala
@@ -160,6 +160,6 @@ class DruidIntegrationTestSuite
     val expectedResult = new Interval(to, to.plusHours(1))
     val response =
       coordinatorClient.listMissingIntervals(new Interval(from, to.plusHours(1)), Granularity.HOUR, "gwiq")
-    response.get shouldBe Vector(expectedResult.toString)
+    response.get.get shouldBe Vector(expectedResult.toString)
   }
 }

--- a/client/src/test/scala/gwi/druid/client/DruidIntegrationTestSuite.scala
+++ b/client/src/test/scala/gwi/druid/client/DruidIntegrationTestSuite.scala
@@ -3,7 +3,7 @@ package gwi.druid.client
 import com.typesafe.scalalogging.LazyLogging
 import gwi.druid.utils.Granularity
 import gwi.randagen._
-import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.{DateTime, DateTimeZone, Interval}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
 
@@ -37,14 +37,20 @@ class DruidIntegrationTestSuite
   val overlordHost = sys.env.getOrElse(
     "OVERLORD_HOST",
     throw new IllegalStateException(s"BROKER_HOST env var must be defined !!!"))
+  val coordinatorHost = sys.env.getOrElse(
+    "COORDINATOR_HOST",
+    throw new IllegalStateException(s"COORDINATOR_HOST env var must be defined !!!"))
 
   lazy private val brokerClient =
     DruidClient.forQueryingBroker(brokerHost)(5.seconds, 1.minute)
   lazy private val overlordClient =
     DruidClient.forIndexing(overlordHost)(5.seconds, 5.seconds, 3.minute)
+  lazy private val coordinatorClient =
+    DruidClient.forQueryingCoordinator(coordinatorHost)(10.seconds, 30.seconds)
 
   require(brokerClient.isHealthy.get, "Broker is not healthy !!!")
   require(overlordClient.isHealthy.get, "Overlord is not healthy !!!")
+  require(coordinatorClient.isHealthy.get, "Coordinator is not healthy !!!")
 
   def indexTestData(): Unit = {
     logger.info(s"Data generation initialized ...")
@@ -148,5 +154,12 @@ class DruidIntegrationTestSuite
       response.result.map(_(purchaseFieldName)).toSet)
     assertResult(sampleSize)(
       response.result.map(_(priceSumAggName).toString.toInt).sum)
+  }
+
+  "missing intervals" in {
+    val expectedResult = new Interval(to, to.plusHours(1))
+    val response =
+      coordinatorClient.listMissingIntervals(new Interval(from, to.plusHours(1)), Granularity.HOUR, "gwiq")
+    response.get shouldBe Vector(expectedResult.toString)
   }
 }


### PR DESCRIPTION
We need means of checking whether druid datasources contain allpartitions, as indexing thousands of partitions may lead to a lot of failures either on druid or argo side and it is hard to tell what is missing.

Tests are failing because it uses staging druid which is busy by reindexing ...